### PR TITLE
Only pass fuzzlyn arg if proc isn't self-hosted

### DIFF
--- a/Fuzzlyn/Execution/ProgramExecutor.cs
+++ b/Fuzzlyn/Execution/ProgramExecutor.cs
@@ -85,7 +85,7 @@ namespace Fuzzlyn.Execution
             ProcessStartInfo info = new ProcessStartInfo
             {
                 FileName = dotnet,
-                Arguments = $"\"{fuzzlyn}\" --execute-programs",
+                Arguments = " --execute-programs",
                 WorkingDirectory = fuzzlynDir,
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,

--- a/Fuzzlyn/Execution/ProgramExecutor.cs
+++ b/Fuzzlyn/Execution/ProgramExecutor.cs
@@ -82,7 +82,7 @@ namespace Fuzzlyn.Execution
 
             string fuzzlyn = Assembly.GetExecutingAssembly().Location;
             string fuzzlynDir = Path.GetDirectoryName(fuzzlyn);
-            bool hostIsFuzzlyn = host.Equals("fuzzlyn", StringComparison.OrdinalIgnoreCase);
+            bool hostIsFuzzlyn = fuzzlyn == host;
             ProcessStartInfo info = new ProcessStartInfo
             {
                 FileName = host,

--- a/Fuzzlyn/Execution/ProgramExecutor.cs
+++ b/Fuzzlyn/Execution/ProgramExecutor.cs
@@ -86,7 +86,7 @@ namespace Fuzzlyn.Execution
             ProcessStartInfo info = new ProcessStartInfo
             {
                 FileName = host,
-                Arguments = hostIsFuzzlyn ? " --execute-programs" : "fuzzlyn --execute-programs",
+                Arguments = hostIsFuzzlyn ? "--execute-programs" : "\"{fuzzlyn}\" --execute-programs",
                 WorkingDirectory = fuzzlynDir,
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,

--- a/Fuzzlyn/Execution/ProgramExecutor.cs
+++ b/Fuzzlyn/Execution/ProgramExecutor.cs
@@ -73,19 +73,20 @@ namespace Fuzzlyn.Execution
         // Launches a new instance of Fuzzlyn to run the specified programs in.
         public static List<ProgramPairResults> RunSeparately(List<ProgramPair> programs)
         {
-            string dotnet;
+            string host;
             using (Process proc = Process.GetCurrentProcess())
             using (ProcessModule mm = proc.MainModule)
             {
-                dotnet = mm.FileName;
+                host = mm.FileName;
             }
 
             string fuzzlyn = Assembly.GetExecutingAssembly().Location;
             string fuzzlynDir = Path.GetDirectoryName(fuzzlyn);
+            bool hostIsFuzzlyn = host.Equals("fuzzlyn", StringComparison.OrdinalIgnoreCase);
             ProcessStartInfo info = new ProcessStartInfo
             {
-                FileName = dotnet,
-                Arguments = " --execute-programs",
+                FileName = host,
+                Arguments = hostIsFuzzlyn ? " --execute-programs" : "fuzzlyn --execute-programs",
                 WorkingDirectory = fuzzlynDir,
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,


### PR DESCRIPTION
See #5 - this is a small PR that removes `fuzzlyn` as the first arg, since we're now running as our own proc instead of as a child of `dotnet`.