### PR TITLE
Add support for try/catch

### DIFF
--- a/Fuzzlyn/Fuzzlyn.csproj
+++ b/Fuzzlyn/Fuzzlyn.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>2.7</Version>
+    <Version>2.8</Version>
     <TieredCompilation>false</TieredCompilation>
     <RuntimeIdentifiers>win-x64;win-x86;linux-arm64;linux-arm;osx-arm64</RuntimeIdentifiers>
     <LangVersion>preview</LangVersion>

--- a/Fuzzlyn/FuzzlynOptions.cs
+++ b/Fuzzlyn/FuzzlynOptions.cs
@@ -66,7 +66,9 @@ internal class FuzzlynOptions
             [(int)StatementKind.If] = 0.14,
             [(int)StatementKind.Block] = 0.1,
             [(int)StatementKind.Call] = 0.1,
-            [(int)StatementKind.TryFinally] = 0.05,
+            [(int)StatementKind.Throw] = 0.005,
+            [(int)StatementKind.TryCatch] = 0.015,
+            [(int)StatementKind.TryFinally] = 0.03,
             [(int)StatementKind.Loop] = 0.03,
             [(int)StatementKind.Return] = 0.01,
         });

--- a/Fuzzlyn/KnownErrors.cs
+++ b/Fuzzlyn/KnownErrors.cs
@@ -21,5 +21,6 @@ internal class KnownErrors(IEnumerable<string> errors)
     public static KnownErrors DotnetRuntime { get; } = new KnownErrors(
         [
             "inVarToRegMap[varIndex] == REG_STK",
+            "!fgRngChkThrowAdded"
         ]);
 }

--- a/Fuzzlyn/Methods/FuncBodyGenerator.cs
+++ b/Fuzzlyn/Methods/FuncBodyGenerator.cs
@@ -341,11 +341,12 @@ internal class FuncBodyGenerator(
 
         return
             ThrowStatement(
-                InvocationExpression(
-                    MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
+                ObjectCreationExpression(
+                    QualifiedName(
                         IdentifierName("System"),
-                        IdentifierName("Exception"))));
+                        IdentifierName("Exception")))
+                .WithArgumentList(
+                    ArgumentList()));
     }
 
     private StatementSyntax GenTryCatch()

--- a/Fuzzlyn/Methods/FuncBodyGenerator.cs
+++ b/Fuzzlyn/Methods/FuncBodyGenerator.cs
@@ -34,10 +34,8 @@ internal class FuncBodyGenerator(
     private readonly bool _isInPrimaryClass = isInPrimaryClass;
 
     private readonly List<ScopeFrame> _scope = new();
-    private int _tryFinallyCount;
     private int _tryCatchCount;
     private int _finallyCount;
-    private int _catchCount;
     private int _varCounter;
     private int _statementLevel = -1;
 
@@ -55,7 +53,7 @@ internal class FuncBodyGenerator(
 
     private StatementSyntax GenStatement(bool allowReturn = true)
     {
-        if (_finallyCount > 0 || _catchCount > 0)
+        if (_finallyCount > 0)
             allowReturn = false;
 
         while (true)
@@ -363,9 +361,7 @@ internal class FuncBodyGenerator(
         if (!doCatchWhen)
             _tryCatchCount--;
 
-        _catchCount++;
         BlockSyntax catchBody = GenBlock(numStatements: catchStatements);
-        _catchCount--;
 
         if (doCatchWhen)
         {
@@ -412,9 +408,7 @@ internal class FuncBodyGenerator(
         int tryStatements = _random.Next(numStatements);
         int finallyStatements = numStatements - tryStatements;
 
-        _tryFinallyCount++;
         BlockSyntax body = GenBlock(numStatements: tryStatements);
-        _tryFinallyCount--;
         _finallyCount++;
         BlockSyntax finallyBody = GenBlock(numStatements: finallyStatements);
         _finallyCount--;

--- a/Fuzzlyn/Reduction/Reducer.cs
+++ b/Fuzzlyn/Reduction/Reducer.cs
@@ -1754,7 +1754,7 @@ public class Runtime : IRuntime
     }
 
     [Simplifier]
-    private IEnumerable<SyntaxNode> SimplifyTryFinally(SyntaxNode node)
+    private IEnumerable<SyntaxNode> SimplifyTry(SyntaxNode node)
     {
         if (node is not TryStatementSyntax @try)
             yield break;

--- a/Fuzzlyn/Reduction/Reducer.cs
+++ b/Fuzzlyn/Reduction/Reducer.cs
@@ -1756,15 +1756,25 @@ public class Runtime : IRuntime
     [Simplifier]
     private IEnumerable<SyntaxNode> SimplifyTryFinally(SyntaxNode node)
     {
-        if (node is not TryStatementSyntax @try || @try.Catches.Any())
+        if (node is not TryStatementSyntax @try)
             yield break;
 
         yield return @try.Block;
-        yield return @try.Finally.Block;
-        yield return Block(@try.Block, @try.Finally.Block);
-        // Try finally first and then block. Useful when the try-block contains a
-        // return.
-        yield return Block(@try.Finally.Block, @try.Block);
+
+        if (@try.Finally != null)
+        {
+            yield return @try.Finally.Block;
+            yield return Block(@try.Block, @try.Finally.Block);
+            // Try finally first and then block. Useful when the try-block contains a
+            // return.
+            yield return Block(@try.Finally.Block, @try.Block);
+        }
+
+        if (@try.Catches.Any())
+        {
+            foreach (CatchClauseSyntax @catch in @try.Catches)
+                yield return @catch;
+        }
     }
 
     [Simplifier]

--- a/Fuzzlyn/Reduction/Reducer.cs
+++ b/Fuzzlyn/Reduction/Reducer.cs
@@ -1769,12 +1769,6 @@ public class Runtime : IRuntime
             // return.
             yield return Block(@try.Finally.Block, @try.Block);
         }
-
-        if (@try.Catches.Any())
-        {
-            foreach (CatchClauseSyntax @catch in @try.Catches)
-                yield return @catch;
-        }
     }
 
     [Simplifier]


### PR DESCRIPTION
1. Generate `try/catch`, with catch of `System.Exception`
2. Sometimes generate `throw new System.Exception()` if we're generating a statement within a `try` of a `try/catch` construct.
3. Generate `try/catch/when(expression)`. In this case, don't generate `throw` because we don't know if the expression will be true.

Case (3) exposes lots of https://github.com/dotnet/runtime/issues/114985, so add that assertion to the known errors list for dotnet/runtime.
