### PR TITLE
Encourage loop cloning

### DIFF
--- a/Fuzzlyn/Fuzzlyn.csproj
+++ b/Fuzzlyn/Fuzzlyn.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>2.8</Version>
+    <Version>2.9</Version>
     <TieredCompilation>false</TieredCompilation>
     <RuntimeIdentifiers>win-x64;win-x86;linux-arm64;linux-arm;osx-arm64</RuntimeIdentifiers>
     <LangVersion>preview</LangVersion>

--- a/Fuzzlyn/FuzzlynOptions.cs
+++ b/Fuzzlyn/FuzzlynOptions.cs
@@ -110,6 +110,7 @@ internal class FuzzlynOptions
     public double PickLiteralFromTableProb { get; set; } = 0.5;
     public double ForLoopProb { get; set; } = 0.8;
     public double UpCountedLoopProb { get; set; } = 0.5;
+    public double SmallLoopIterationCountProb { get; set; } = 0.25;
 
     public ProbabilityDistribution SignedIntegerTypicalLiteralDist { get; set; }
         = new TableDistribution(new Dictionary<int, double>

--- a/Fuzzlyn/FuzzlynOptions.cs
+++ b/Fuzzlyn/FuzzlynOptions.cs
@@ -246,6 +246,8 @@ internal class FuzzlynOptions
             [(int)VectorCreationKind.CreateBroadcast] = 0.44,
             [(int)VectorCreationKind.CreateScalar] = 0.44,
         });
+
+    public ProbabilityDistribution SwitchCaseCountDist { get; set; } = new GeometricDistribution(0.2, 5);
 }
 
 internal enum AggregateFieldKind

--- a/Fuzzlyn/FuzzlynOptions.cs
+++ b/Fuzzlyn/FuzzlynOptions.cs
@@ -63,7 +63,8 @@ internal class FuzzlynOptions
         = new TableDistribution(new Dictionary<int, double>
         {
             [(int)StatementKind.Assignment] = 0.57,
-            [(int)StatementKind.If] = 0.14,
+            [(int)StatementKind.If] = 0.135,
+            [(int)StatementKind.Switch] = 0.005,
             [(int)StatementKind.Block] = 0.1,
             [(int)StatementKind.Call] = 0.1,
             [(int)StatementKind.Throw] = 0.005,

--- a/Fuzzlyn/LiteralGenerator.cs
+++ b/Fuzzlyn/LiteralGenerator.cs
@@ -75,7 +75,7 @@ internal static class LiteralGenerator
             kind = (TypicalLiteralKind)random.Options.SignedIntegerTypicalLiteralDist.Sample(random.Rng);
         }
 
-        return primType.Info.GenTypicalLiteralLoopBounds(kind);
+        return primType.Info.GenTypicalLiteralLoopBounds(kind, random);
     }
 
     private static List<int> GenArrayDimensions(Randomizer random, ArrayType at)

--- a/Fuzzlyn/Methods/FuncBodyGenerator.cs
+++ b/Fuzzlyn/Methods/FuncBodyGenerator.cs
@@ -353,7 +353,7 @@ internal class FuncBodyGenerator(
         // numeric cases, to attempt to get Roslyn to generate a 'switch' IL instruction.
 
         List<SwitchSectionSyntax> switchSections = new();
-        int caseCount = _random.Next(5, 25);
+        int caseCount = Options.SwitchCaseCountDist.Sample(_random.Rng);
         for (int caseNumber = 0; caseNumber < caseCount; caseNumber++)
         {
             ExpressionSyntax caseValue = LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(caseNumber));

--- a/Fuzzlyn/Program.cs
+++ b/Fuzzlyn/Program.cs
@@ -191,6 +191,9 @@ internal class Program
         }
         else if (options.Stats)
         {
+            if (options.GenExtensions == null)
+                options.GenExtensions = []; // No extension by default with --stats
+
             GenerateProgramsAndGetStats(options);
         }
         else

--- a/Fuzzlyn/Reduction/Reducer.cs
+++ b/Fuzzlyn/Reduction/Reducer.cs
@@ -1324,6 +1324,26 @@ public class Runtime : IRuntime
     }
 
     [Simplifier]
+    private IEnumerable<SyntaxNode> SimplifySwitch(SyntaxNode node)
+    {
+        if (node is not SwitchStatementSyntax @switch)
+            yield break;
+
+        foreach (var section in @switch.Sections)
+        {
+            // Remove the 'break;' statement
+            if (section.Statements.Count > 0)
+            {
+                var lastStmt = section.Statements.Last();
+                if (lastStmt is BreakStatementSyntax)
+                    yield return Block(section.Statements.RemoveAt(section.Statements.Count - 1));
+                else
+                    yield return Block(section.Statements);
+            }
+        }
+    }
+
+    [Simplifier]
     private IEnumerable<SyntaxNode> SimplifyFor(SyntaxNode node)
     {
         if (node is not ForStatementSyntax @for)

--- a/Fuzzlyn/Types/PrimitiveType.cs
+++ b/Fuzzlyn/Types/PrimitiveType.cs
@@ -92,9 +92,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithSuffix<ulong>(rng.NextUInt64(), null, "UL", (val, str) => Literal(val, str)),
                 GenTypicalLiteral = literal => CreateLiteralWithSuffix<ulong>(FromTypicalLiteral<ulong>(literal), null, "UL", (val, str) => Literal(val, str)),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithSuffix<ulong>(FromTypicalLiteralLoopLowerBound<ulong>(literal), null, "UL", (val, str) => Literal(val, str)),
-                    CreateLiteralWithSuffix<ulong>(FromTypicalLiteralLoopUpperBound<ulong>(literal), null, "UL", (val, str) => Literal(val, str))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithSuffix<ulong>(FromTypicalLiteralLoopLowerBound<ulong>(literal, random), null, "UL", (val, str) => Literal(val, str)),
+                    CreateLiteralWithSuffix<ulong>(FromTypicalLiteralLoopUpperBound<ulong>(literal, random), null, "UL", (val, str) => Literal(val, str))),
                 GenInRange = (min, max, rng) => CreateLiteralWithSuffix<ulong>(RandomMinMax<ulong>(min, max, rng), null, "UL", (val, str) => Literal(val, str)),
                 IsUnsigned = true,
                 IsNumeric = true,
@@ -105,9 +105,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithSuffix<long>((long)rng.NextUInt64(), null, "L", (val, str) => Literal(val, str)),
                 GenTypicalLiteral = literal => CreateLiteralWithSuffix<long>(FromTypicalLiteral<long>(literal), null, "L", (val, str) => Literal(val, str)),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithSuffix<long>(FromTypicalLiteralLoopLowerBound<long>(literal), null, "L", (val, str) => Literal(val, str)),
-                    CreateLiteralWithSuffix<long>(FromTypicalLiteralLoopUpperBound<long>(literal), null, "L", (val, str) => Literal(val, str))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithSuffix<long>(FromTypicalLiteralLoopLowerBound<long>(literal, random), null, "L", (val, str) => Literal(val, str)),
+                    CreateLiteralWithSuffix<long>(FromTypicalLiteralLoopUpperBound<long>(literal, random), null, "L", (val, str) => Literal(val, str))),
                 GenInRange = (min, max, rng) => CreateLiteralWithSuffix<long>(RandomMinMax<long>(min, max, rng), null, "L", (val, str) => Literal(val, str)),
                 IsNumeric = true,
                 Size = sizeof(long),
@@ -117,9 +117,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithSuffix<uint>((uint)rng.NextUInt64(), null, "U", (val, str) => Literal(val, str)),
                 GenTypicalLiteral = literal => CreateLiteralWithSuffix<uint>(FromTypicalLiteral<uint>(literal), null, "U", (val, str) => Literal(val, str)),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithSuffix<uint>(FromTypicalLiteralLoopLowerBound<uint>(literal), null, "U", (val, str) => Literal(val, str)),
-                    CreateLiteralWithSuffix<uint>(FromTypicalLiteralLoopUpperBound<uint>(literal), null, "U", (val, str) => Literal(val, str))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithSuffix<uint>(FromTypicalLiteralLoopLowerBound<uint>(literal, random), null, "U", (val, str) => Literal(val, str)),
+                    CreateLiteralWithSuffix<uint>(FromTypicalLiteralLoopUpperBound<uint>(literal, random), null, "U", (val, str) => Literal(val, str))),
                 GenInRange = (min, max, rng) => CreateLiteralWithSuffix<uint>(RandomMinMax<uint>(min, max, rng), null, "U", (val, str) => Literal(val, str)),
                 IsUnsigned = true,
                 IsNumeric = true,
@@ -130,9 +130,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)rng.NextUInt64())),
                 GenTypicalLiteral = literal => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(FromTypicalLiteral<int>(literal))),
-                GenTypicalLiteralLoopBounds = literal => (
-                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(FromTypicalLiteralLoopLowerBound<int>(literal))),
-                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(FromTypicalLiteralLoopUpperBound<int>(literal)))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(FromTypicalLiteralLoopLowerBound<int>(literal, random))),
+                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(FromTypicalLiteralLoopUpperBound<int>(literal, random)))),
                 GenInRange = (min, max, rng) => LiteralExpression(SyntaxKind.NumericLiteralToken, Literal(RandomMinMax<uint>(min, max, rng))),
                 IsNumeric = true,
                 Size = sizeof(int),
@@ -142,9 +142,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithCast<ushort>(Literal((ushort)rng.NextUInt64()), SyntaxKind.UShortKeyword),
                 GenTypicalLiteral = literal => CreateLiteralWithCast<ushort>(Literal(FromTypicalLiteral<ushort>(literal)), SyntaxKind.UShortKeyword),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithCast<ushort>(Literal(FromTypicalLiteralLoopLowerBound<ushort>(literal)), SyntaxKind.UShortKeyword),
-                    CreateLiteralWithCast<ushort>(Literal(FromTypicalLiteralLoopUpperBound<ushort>(literal)), SyntaxKind.UShortKeyword)),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithCast<ushort>(Literal(FromTypicalLiteralLoopLowerBound<ushort>(literal, random)), SyntaxKind.UShortKeyword),
+                    CreateLiteralWithCast<ushort>(Literal(FromTypicalLiteralLoopUpperBound<ushort>(literal, random)), SyntaxKind.UShortKeyword)),
                 GenInRange = (min, max, rng) => CreateLiteralWithCast<ushort>(Literal(RandomMinMax<ushort>(min, max, rng)), SyntaxKind.UShortKeyword),
                 IsUnsigned = true,
                 IsNumeric = true,
@@ -155,9 +155,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithCast<short>(Literal((short)rng.NextUInt64()), SyntaxKind.ShortKeyword),
                 GenTypicalLiteral = literal => CreateLiteralWithCast<short>(Literal(FromTypicalLiteral<short>(literal)), SyntaxKind.ShortKeyword),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithCast<short>(Literal(FromTypicalLiteralLoopLowerBound<short>(literal)), SyntaxKind.ShortKeyword),
-                    CreateLiteralWithCast<short>(Literal(FromTypicalLiteralLoopUpperBound<short>(literal)), SyntaxKind.ShortKeyword)),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithCast<short>(Literal(FromTypicalLiteralLoopLowerBound<short>(literal, random)), SyntaxKind.ShortKeyword),
+                    CreateLiteralWithCast<short>(Literal(FromTypicalLiteralLoopUpperBound<short>(literal, random)), SyntaxKind.ShortKeyword)),
                 GenInRange = (min, max, rng) => CreateLiteralWithCast<short>(Literal(RandomMinMax<short>(min, max, rng)), SyntaxKind.ShortKeyword),
                 IsNumeric = true,
                 Size = sizeof(short),
@@ -167,9 +167,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithCast<byte>(Literal((byte)rng.NextUInt64()), SyntaxKind.ByteKeyword),
                 GenTypicalLiteral = literal => CreateLiteralWithCast<byte>(Literal(FromTypicalLiteral<byte>(literal)), SyntaxKind.ByteKeyword),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithCast<byte>(Literal(FromTypicalLiteralLoopLowerBound<byte>(literal)), SyntaxKind.ByteKeyword),
-                    CreateLiteralWithCast<byte>(Literal(FromTypicalLiteralLoopUpperBound<byte>(literal)), SyntaxKind.ByteKeyword)),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithCast<byte>(Literal(FromTypicalLiteralLoopLowerBound<byte>(literal, random)), SyntaxKind.ByteKeyword),
+                    CreateLiteralWithCast<byte>(Literal(FromTypicalLiteralLoopUpperBound<byte>(literal, random)), SyntaxKind.ByteKeyword)),
                 GenInRange = (min, max, rng) => CreateLiteralWithCast<byte>(Literal(RandomMinMax<byte>(min, max, rng)), SyntaxKind.ByteKeyword),
                 IsUnsigned = true,
                 IsNumeric = true,
@@ -180,9 +180,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = intAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithCast<sbyte>(Literal((sbyte)rng.NextUInt64()), SyntaxKind.SByteKeyword),
                 GenTypicalLiteral = literal => CreateLiteralWithCast<sbyte>(Literal(FromTypicalLiteral<sbyte>(literal)), SyntaxKind.SByteKeyword),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithCast<sbyte>(Literal(FromTypicalLiteralLoopLowerBound<sbyte>(literal)), SyntaxKind.SByteKeyword),
-                    CreateLiteralWithCast<sbyte>(Literal(FromTypicalLiteralLoopUpperBound<sbyte>(literal)), SyntaxKind.SByteKeyword)),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithCast<sbyte>(Literal(FromTypicalLiteralLoopLowerBound<sbyte>(literal, random)), SyntaxKind.SByteKeyword),
+                    CreateLiteralWithCast<sbyte>(Literal(FromTypicalLiteralLoopUpperBound<sbyte>(literal, random)), SyntaxKind.SByteKeyword)),
                 GenInRange = (min, max, rng) => CreateLiteralWithCast<sbyte>(Literal(RandomMinMax<sbyte>(min, max, rng)), SyntaxKind.SByteKeyword),
                 IsNumeric = true,
                 Size = sizeof(sbyte),
@@ -192,9 +192,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = floatAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithSuffix<float>((float)((rng.NextDouble() - 0.5) * 1000), "R", "f", (val, str) => Literal(val, str)),
                 GenTypicalLiteral = literal => CreateLiteralWithSuffix<float>(FromTypicalLiteral<float>(literal), "R", "f", (val, str) => Literal(val, str)),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithSuffix<float>(FromTypicalLiteralLoopLowerBound<float>(literal), "R", "f", (val, str) => Literal(val, str)),
-                    CreateLiteralWithSuffix<float>(FromTypicalLiteralLoopUpperBound<float>(literal), "R", "f", (val, str) => Literal(val, str))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithSuffix<float>(FromTypicalLiteralLoopLowerBound<float>(literal, random), "R", "f", (val, str) => Literal(val, str)),
+                    CreateLiteralWithSuffix<float>(FromTypicalLiteralLoopUpperBound<float>(literal, random), "R", "f", (val, str) => Literal(val, str))),
                 GenInRange = (min, max, rng) => throw new InvalidOperationException(),
                 IsNumeric = true,
                 IsFloat = true,
@@ -205,9 +205,9 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = floatAssigns,
                 GenRandomLiteral = rng => CreateLiteralWithSuffix<double>((double)((rng.NextDouble() - 0.5) * 10000), "R", "d", (val, str) => Literal(val, str)),
                 GenTypicalLiteral = literal => CreateLiteralWithSuffix<double>(FromTypicalLiteral<double>(literal), "R", "d", (val, str) => Literal(val, str)),
-                GenTypicalLiteralLoopBounds = literal => (
-                    CreateLiteralWithSuffix<double>(FromTypicalLiteralLoopLowerBound<double>(literal), "R", "d", (val, str) => Literal(val, str)),
-                    CreateLiteralWithSuffix<double>(FromTypicalLiteralLoopUpperBound<double>(literal), "R", "d", (val, str) => Literal(val, str))),
+                GenTypicalLiteralLoopBounds = (literal, random) => (
+                    CreateLiteralWithSuffix<double>(FromTypicalLiteralLoopLowerBound<double>(literal, random), "R", "d", (val, str) => Literal(val, str)),
+                    CreateLiteralWithSuffix<double>(FromTypicalLiteralLoopUpperBound<double>(literal, random), "R", "d", (val, str) => Literal(val, str))),
                 GenInRange = (min, max, rng) => throw new InvalidOperationException(),
                 IsNumeric = true,
                 IsFloat = true,
@@ -218,7 +218,7 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
                 AllowedAdditionalAssignments = boolAssigns,
                 GenRandomLiteral = rng => LiteralExpression(rng.Next(2) == 0 ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression),
                 GenTypicalLiteral = literal => throw new InvalidOperationException(),
-                GenTypicalLiteralLoopBounds = literal => throw new InvalidOperationException(),
+                GenTypicalLiteralLoopBounds = (literal, random) => throw new InvalidOperationException(),
                 GenInRange = (min, max, rng) => throw new InvalidOperationException(),
                 Size = sizeof(bool),
             },
@@ -257,7 +257,7 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
         };
     }
 
-    private static T FromTypicalLiteralLoopLowerBound<T>(TypicalLiteralKind literal) where T : INumber<T>, IMinMaxValue<T>
+    private static T FromTypicalLiteralLoopLowerBound<T>(TypicalLiteralKind literal, Randomizer random) where T : INumber<T>, IMinMaxValue<T>
     {
         return literal switch
         {
@@ -271,27 +271,30 @@ public class PrimitiveType(SyntaxKind keyword) : FuzzType, IEquatable<PrimitiveT
             TypicalLiteralKind.Two => T.CreateChecked(2),
             TypicalLiteralKind.Ten => T.CreateChecked(10),
             TypicalLiteralKind.MaxValueMinusOne => T.MaxValue - T.CreateChecked(100), // This is a bit misnamed for loop bounds
-            TypicalLiteralKind.MaxValue => T.MaxValue - T.CreateChecked(5), // This is a bit misnamed for loop bounds, since we need space after it
+            TypicalLiteralKind.MaxValue => T.MaxValue - T.CreateChecked(50), // This is a bit misnamed for loop bounds, since we need space after it
             _ => throw new ArgumentOutOfRangeException(nameof(literal)),
         };
     }
 
-    // TODO: handle varying loop iteration counts
-    private static T FromTypicalLiteralLoopUpperBound<T>(TypicalLiteralKind literal) where T : INumber<T>, IMinMaxValue<T>
+    private static T FromTypicalLiteralLoopUpperBound<T>(TypicalLiteralKind literal, Randomizer random) where T : INumber<T>, IMinMaxValue<T>
     {
+        // An iteration count of 2 leads to JIT loop unrolling (if size contraints apply). An iteration count of 40 is larger
+        // than the JIT allowed constant loop iteration unroll count, and leads to loop cloning.
+        T iterationCount = random.FlipCoin(random.Options.SmallLoopIterationCountProb) ? T.CreateChecked(2) : T.CreateChecked(40);
+
         return literal switch
         {
-            TypicalLiteralKind.MinValue => T.MinValue + T.CreateChecked(2),
-            TypicalLiteralKind.MinValuePlusOne => T.MinValue + T.One + T.CreateChecked(2),
-            TypicalLiteralKind.MinusTen => T.CreateChecked(-10) + T.CreateChecked(2),
-            TypicalLiteralKind.MinusTwo => T.CreateChecked(-2) + T.CreateChecked(2),
-            TypicalLiteralKind.MinusOne => T.CreateChecked(-1) + T.CreateChecked(2),
-            TypicalLiteralKind.Zero => T.Zero + T.CreateChecked(2),
-            TypicalLiteralKind.One => T.One + T.CreateChecked(2),
-            TypicalLiteralKind.Two => T.CreateChecked(2) + T.CreateChecked(2),
-            TypicalLiteralKind.Ten => T.CreateChecked(10) + T.CreateChecked(2),
-            TypicalLiteralKind.MaxValueMinusOne => T.MaxValue - T.CreateChecked(100) + T.CreateChecked(2),
-            TypicalLiteralKind.MaxValue => T.MaxValue - T.CreateChecked(5) + T.CreateChecked(2),
+            TypicalLiteralKind.MinValue => T.MinValue + iterationCount,
+            TypicalLiteralKind.MinValuePlusOne => T.MinValue + T.One + iterationCount,
+            TypicalLiteralKind.MinusTen => T.CreateChecked(-10) + iterationCount,
+            TypicalLiteralKind.MinusTwo => T.CreateChecked(-2) + iterationCount,
+            TypicalLiteralKind.MinusOne => T.CreateChecked(-1) + iterationCount,
+            TypicalLiteralKind.Zero => T.Zero + iterationCount,
+            TypicalLiteralKind.One => T.One + iterationCount,
+            TypicalLiteralKind.Two => T.CreateChecked(2) + iterationCount,
+            TypicalLiteralKind.Ten => T.CreateChecked(10) + iterationCount,
+            TypicalLiteralKind.MaxValueMinusOne => T.MaxValue - T.CreateChecked(100) + iterationCount,
+            TypicalLiteralKind.MaxValue => T.MaxValue - T.CreateChecked(50) + iterationCount,
             _ => throw new ArgumentOutOfRangeException(nameof(literal)),
         };
     }
@@ -334,7 +337,7 @@ internal class PrimitiveTypeInfo
     public SyntaxKind[] AllowedAdditionalAssignments { get; set; }
     public Func<Rng, ExpressionSyntax> GenRandomLiteral { get; set; }
     public Func<TypicalLiteralKind, ExpressionSyntax> GenTypicalLiteral { get; set; }
-    public Func<TypicalLiteralKind, (ExpressionSyntax, ExpressionSyntax)> GenTypicalLiteralLoopBounds { get; set; }
+    public Func<TypicalLiteralKind, Randomizer, (ExpressionSyntax, ExpressionSyntax)> GenTypicalLiteralLoopBounds { get; set; }
     public Func<int?, int?, Rng, ExpressionSyntax> GenInRange { get; set; }
     public bool IsUnsigned { get; set; }
     public bool IsNumeric { get; set; }


### PR DESCRIPTION
A small constant loop iteration count is easy for the JIT to detect, and
leads to the JIT unrolling the loop, if other profitability conditions
occur. It never leads to loop cloning.

Sometimes choosing larger loop bounds does lead to cloning, though in
the cases I tried, less than 0.5% of generated programs ended up with
cloned loops.